### PR TITLE
Add case sensitive .R file extention for make init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 init:
 
-	Rscript requirements.r
+	Rscript requirements.R
 
 fetch_data:
 


### PR DESCRIPTION
I need the case sensitive .R extension to work with Ubunutu.
